### PR TITLE
Refactor all() method in FileStorage class and add delete() method

### DIFF
--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -5,20 +5,28 @@ import json
 
 class FileStorage:
     """This class manages storage of hbnb models in JSON format"""
-    __file_path = 'file.json'
+
+    __file_path = "file.json"
     __objects = {}
 
-    def all(self):
+    def all(self, cls=None):
         """Returns a dictionary of models currently in storage"""
-        return FileStorage.__objects
+        if cls is None:
+            return FileStorage.__objects
+        else:
+            temp = {}
+            for key, val in FileStorage.__objects.items():
+                if cls.__name__ in key:
+                    temp[key] = val
+            return temp
 
     def new(self, obj):
         """Adds new object to storage dictionary"""
-        self.all().update({obj.to_dict()['__class__'] + '.' + obj.id: obj})
+        self.all().update({obj.to_dict()["__class__"] + "." + obj.id: obj})
 
     def save(self):
         """Saves storage dictionary to file"""
-        with open(FileStorage.__file_path, 'w') as f:
+        with open(FileStorage.__file_path, "w") as f:
             temp = {}
             temp.update(FileStorage.__objects)
             for key, val in temp.items():
@@ -36,15 +44,27 @@ class FileStorage:
         from models.review import Review
 
         classes = {
-                    'BaseModel': BaseModel, 'User': User, 'Place': Place,
-                    'State': State, 'City': City, 'Amenity': Amenity,
-                    'Review': Review
-                  }
+            "BaseModel": BaseModel,
+            "User": User,
+            "Place": Place,
+            "State": State,
+            "City": City,
+            "Amenity": Amenity,
+            "Review": Review,
+        }
         try:
             temp = {}
-            with open(FileStorage.__file_path, 'r') as f:
+            with open(FileStorage.__file_path, "r") as f:
                 temp = json.load(f)
                 for key, val in temp.items():
-                        self.all()[key] = classes[val['__class__']](**val)
+                    self.all()[key] = classes[val["__class__"]](**val)
         except FileNotFoundError:
             pass
+
+    def delete(self, obj=None):
+        """Delete obj from __objects if it’s inside"""
+        if obj is not None:
+            key = "{}.{}".format(obj.__class__.__name__, obj.id)
+            if key in self.__objects:
+                del self.__objects[key]
+                self.save()

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -41,6 +41,17 @@ class test_fileStorage(unittest.TestCase):
         temp = storage.all()
         self.assertIsInstance(temp, dict)
 
+    def test_all_with_cls_none(self):
+        """ Test all() method with cls=None """
+        temp = storage.all()
+        self.assertEqual(temp, storage._FileStorage__objects)
+
+    def test_all_with_cls(self):
+        """ Test all() method with cls specified """
+        new = BaseModel()
+        temp = storage.all(BaseModel)
+        self.assertEqual(temp, {'BaseModel.{}'.format(new.id): new})
+
     def test_base_model_instantiation(self):
         """ File is not created on BaseModel save """
         new = BaseModel()
@@ -107,3 +118,23 @@ class test_fileStorage(unittest.TestCase):
         from models.engine.file_storage import FileStorage
         print(type(storage))
         self.assertEqual(type(storage), FileStorage)
+
+    def test_delete_existing_obj(self):
+        """ Delete existing object from __objects """
+        new = BaseModel()
+        storage.save()
+        storage.delete(new)
+        self.assertNotIn('BaseModel.{}'.format(new.id), storage.all())
+
+    def test_delete_nonexistent_obj(self):
+        """ Delete nonexistent object from __objects """
+        new = BaseModel()
+        storage.save()
+        storage.delete(new)
+        self.assertNotIn('BaseModel.{}'.format(new.id), storage.all())
+
+    def test_delete_no_obj(self):
+        """ Delete no object from __objects """
+        storage.save()
+        storage.delete()
+        self.assertEqual(len(storage.all()), 0)


### PR DESCRIPTION
Update `FileStorage: (models/engine/file_storage.py)`

- Add a new public instance method: `def delete(self, obj=None)`: to delete `obj` from `__objects` if it’s inside - if obj is equal to `None`, the method should not do anything
- Update the prototype of `def all(self)` to `def all(self, cls=None)` - that returns the list of objects of one type of class.